### PR TITLE
Typos + support BED files without 'chr' in binUnsorted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=g++ -o scripts/$@ scripts/$@.cpp
 
-all: testBED status interval binUnsorted
+all: testBED status interval binUnsorted CNVcaller
 
 testBED: scripts/testBED.cpp
 	$(CC)
@@ -14,4 +14,6 @@ interval: scripts/interval.cpp
 binUnsorted: scripts/binUnsorted.cpp
 	$(CC)
 
+CNVcaller: scripts/CNVcaller.cpp
+	$(CC)
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ Type ```make``` in the ginkgo/ directory
 - ginkgo/scripts/process.R
 	- Change ```main_dir``` variable to the folder where ginkgo/scripts is located
 
+- ginkgo/scripts/reclust.R
+	- Change ```main_dir``` variable to the folder where ginkgo/scripts is located
+
 - ginkgo/scripts/analyze-subset.R
 	- Set the folder to where ginkgo/scripts is located
 
 **Download data files:**
 
 - Download binning data for hg19 at http://qb.cshl.edu/ginkgo/genomes/hg19/hg19.original.tar.gz
-
-
+	- untar into ginkgo/genomes/hg19 (which needs to be created)

--- a/scripts/binUnsorted.cpp
+++ b/scripts/binUnsorted.cpp
@@ -83,6 +83,9 @@ int main(int argc, char *argv[]){
         bound.first = low_bound;
         bound.second = high_bound-1;
         bin_map[prev_chr]= bound;
+        if (strncmp(prev_chr, "chr", 3) == 0) {
+            bin_map[prev_chr + 3]= bound;
+        }
         low_bound = high_bound;
       }
     skip=false;
@@ -93,6 +96,9 @@ int main(int argc, char *argv[]){
   bound.first = low_bound;
   bound.second = high_bound-2;
   bin_map[new_chr] = bound;
+  if (strncmp(new_chr, "chr", 3) == 0) {
+    bin_map[new_chr + 3]= bound;
+  }
 
 
   char * line = NULL;


### PR DESCRIPTION
Apart from fixing the Makefile and the README.md, the main change is the ability for binUnsorted to process BED files that don't use 'chr' in the chromosome name. This is done by duplicating the keys for the map, such that both 'chr1' and '1' are valid.

Despite this, the rest of the code (namely analyze) still assumes that the BED file needs to include 'chr' in the chromosome name. I haven't changed this as I haven't tested all the options.