### PR TITLE
Issue #13: FACS file parsing breaking

### DIFF
--- a/scripts/process.R
+++ b/scripts/process.R
@@ -400,13 +400,13 @@ for(k in 1:w)
   minSoS = data.frame(x=CNmult[1,k], y=CNerror[1,k])
   bestSoS = data.frame(x=CN, y=outerColsums[which(CNgrid==CN),k])
 
+  limit = c( min(minPloidy, CN), max(maxPloidy, CN))
   plot1 = ggplot() +
-    geom_point(data=minSoS, aes(x=x, y=y*1.02, color="Minimum SoS Error"), shape=18, size=15) +
-    geom_point(data=bestSoS, aes(x=x, y=y*.98, color="Chosen Ploidy"), shape=18, size=15) +
-    scale_x_continuous(limits=c(1.5, 6), breaks=seq(1.5, 6, .5)) +
-    scale_y_continuous(limits=c(.5*min(outerColsums[,k]), top), breaks=seq(0, step[1], step[2])) +
     geom_line(data=sosDat, aes(x=x, y=y), size=3) +
     geom_point(data=sosDat, aes(x=x, y=y), shape=21, fill="black", size=5) +
+    geom_point(data=minSoS, aes(x=x, y=y, color="Minimum SoS Error"), shape=16, size=15, alpha=0.7) +
+    geom_point(data=bestSoS, aes(x=x, y=y, color="Chosen Ploidy"), shape=18, size=15, alpha=0.7) +
+    scale_x_continuous(limits=limit, breaks=seq(limit[1], limit[2], .5)) +
     labs(title="Sum of Squares Error Across Potential Copy Number States", x="Copy Number Multiplier", y="Sum of Squares Error") +
     theme(plot.title=element_text(size=45, vjust=1.5)) +
     theme(axis.title.x=element_text(size=45, vjust=-2.8), axis.title.y=element_text(size=45, vjust=.1)) +

--- a/scripts/process.R
+++ b/scripts/process.R
@@ -216,6 +216,8 @@ for(k in 1:w)
     CN = CNmult[1,k]
   } else if (f == 1) {
     CN = ploidy[which(lab[k]==ploidy[,1]),2]
+    # If user specified FACS file, still calculate CNerror
+    CNerror_facs = round( sort(colSums((round(fixed[,k] %o% c(CN)) - fixed[,k] %o% c(CN)) ^ 2, na.rm=FALSE, dims=1)), digits=2 )
   } else {
     estimate = ploidy[which(lab[k]==ploidy[,1]),2]
     CN = CNmult[which(abs(CNmult[,k] - estimate)<.4),k][1]
@@ -398,7 +400,13 @@ for(k in 1:w)
   lim = cbind(c(seq(0,5000,500), 1000000), c(50, 100, 100, 200, 250, 400, 500, 500, 600, 600, 750, 1000))
   step = lim[which(top<lim[,1])[1],]
   minSoS = data.frame(x=CNmult[1,k], y=CNerror[1,k])
-  bestSoS = data.frame(x=CN, y=outerColsums[which(CNgrid==CN),k])
+  # If a FACS file is provided, use CNerror_facs, since CN multiplier could be 
+  # outside the CNgrid range, which would cause "which(CNgrid==CN)" to error out
+  if(f == 1) {
+    bestSoS = data.frame(x=CN, y=CNerror_facs)    
+  } else {
+    bestSoS = data.frame(x=CN, y=outerColsums[which(CNgrid==CN),k])
+  }
 
   limit = c( min(minPloidy, CN), max(maxPloidy, CN))
   plot1 = ggplot() +


### PR DESCRIPTION
This PR is to address issue #13.

Initially, it seemed like the issue was that, given a FACS file, Ginkgo could only pick a CN multiplier within [1.5, 6], even though a cell was marked as e.g. ploidy 1.3. However, looking more closely at [the code](https://github.com/robertaboukhalil/ginkgo/blob/master/scripts/process.R#L214), the multiplier is correctly set by the FACS file regardless of its value.

So Ginkgo's CN calculation works fine; where it breaks is when it tries to plot the SoS error plot; this is where it assumes the CN multiplier is within [1.5, 6], so this PR updates that SoS plot such that it shows:
- which ploidy Ginkgo would have guessed if no FACS file was provided
- which ploidy was chosen from the FACS file (even if outside [1.5, 6])
- the SoS error for that FACS ploidy

cc: @jpritt: I sent you an invite to become a collaborator on this repo so that I can add you as a reviewer

---

Sample output (with FACS file):
- http://robertaboukhalil.com/data/ginkgo/issue13/facs/hg19.T1_SoS.jpeg
- http://robertaboukhalil.com/data/ginkgo/issue13/facs/hg19.T2_SoS.jpeg
- http://robertaboukhalil.com/data/ginkgo/issue13/facs/hg19.T3_SoS.jpeg

Sample output (without FACS file):
- http://robertaboukhalil.com/data/ginkgo/issue13/nofacs/hg19.T1_SoS.jpeg
- http://robertaboukhalil.com/data/ginkgo/issue13/nofacs/hg19.T2_SoS.jpeg
- http://robertaboukhalil.com/data/ginkgo/issue13/nofacs/hg19.T3_SoS.jpeg

(hg19.T1 is the cell that currently fails in Ginkgo)